### PR TITLE
fix: Regression on browser history due to replaceState proxy

### DIFF
--- a/src/AppProgressBar.tsx
+++ b/src/AppProgressBar.tsx
@@ -150,15 +150,20 @@ export const Next13ProgressBar = React.memo(
       const mutationObserver = new MutationObserver(handleMutation);
       mutationObserver.observe(document, { childList: true, subtree: true });
 
-      const proxyStateChange = new Proxy(window.history.pushState, {
+     
+      window.history.pushState = new Proxy(window.history.pushState, {
         apply: (target, thisArg, argArray: PushStateInput) => {
           stopProgress();
           return target.apply(thisArg, argArray);
         },
       });
-
-      window.history.pushState = proxyStateChange;
-      window.history.replaceState = proxyStateChange;
+      
+      window.history.replaceState = new Proxy(window.history.replaceState, {
+        apply: (target, thisArg, argArray: PushStateInput) => {
+          stopProgress();
+          return target.apply(thisArg, argArray);
+        },
+      });
       
     }, []);
 

--- a/src/AppProgressBar.tsx
+++ b/src/AppProgressBar.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react';
-import NProgress from 'nprogress';
-import { usePathname, useSearchParams, useRouter as useNextRouter } from 'next/navigation';
-import { Next13ProgressProps } from '.';
 import { NavigateOptions } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { useRouter as useNextRouter, usePathname, useSearchParams } from 'next/navigation';
+import NProgress from 'nprogress';
+import React, { useEffect } from 'react';
+import { Next13ProgressProps } from '.';
 
 type PushStateInput = [data: any, unused: string, url?: string | URL | null | undefined];
 
@@ -150,21 +150,19 @@ export const Next13ProgressBar = React.memo(
       const mutationObserver = new MutationObserver(handleMutation);
       mutationObserver.observe(document, { childList: true, subtree: true });
 
-     
-      window.history.pushState = new Proxy(window.history.pushState, {
-        apply: (target, thisArg, argArray: PushStateInput) => {
-          stopProgress();
-          return target.apply(thisArg, argArray);
-        },
-      });
-      
-      window.history.replaceState = new Proxy(window.history.replaceState, {
-        apply: (target, thisArg, argArray: PushStateInput) => {
-          stopProgress();
-          return target.apply(thisArg, argArray);
-        },
-      });
-      
+      const makeStopProxy = (proxyTarget: any) => {
+        return new Proxy(proxyTarget, {
+          apply: (target, thisArg, argArray: PushStateInput) => {
+            stopProgress();
+            return target.apply(thisArg, argArray);
+          },
+        });
+      };
+
+      window.history.pushState = makeStopProxy(window.history.pushState);
+
+      window.history.replaceState = makeStopProxy(window.history.replaceState);
+
     }, []);
 
     return styles;


### PR DESCRIPTION
I made an error on: https://github.com/ndungtse/next13-progressbar/pull/32

By appliying same Proxy on pushState en replaceState this cause a regression and create issue on browser history


Because here the proxy is based on history.pushState also for replaceState. (` new Proxy(window.history.pushState, {`)
```ts
 const proxyStateChange = new Proxy(window.history.pushState, {
        apply: (target, thisArg, argArray: PushStateInput) => {
          stopProgress();
          return target.apply(thisArg, argArray);
        },
      });

window.history.pushState = proxyStateChange;
window.history.replaceState = proxyStateChange;
      
```